### PR TITLE
Update for CD support.

### DIFF
--- a/0patchoo.sh
+++ b/0patchoo.sh
@@ -148,11 +148,11 @@ macaddress=$(networksetup -getmacaddress en0 | awk '{ print $3 }' | sed 's/:/./g
 OLDIFS="$IFS"
 IFS=$'\n'
 
-#if [ ! -d "$cdialog" ]
-#then
-#	echo "FATAL: I can't find cocoadialog, stopping 'ere"
-#	exit 1
-#fi
+if [ ! -d "$cdialog" ]
+then
+	echo "FATAL: I can't find cocoadialog, stopping 'ere"
+	exit 1
+fi
 
 # command line paramaters
 mode="$4"
@@ -179,14 +179,15 @@ jssurl=$(defaults read /Library/Preferences/com.jamfsoftware.jamf "jss_url" 2> /
 daystamp=$(( $(date +%s) / 86400 )) # days since 1-1-70
 
 # due to issue with cocoaDialog outside of user session, this check as been added
-case $osxversion in	
-	10.5 | 10.6 | 10.7 | 10.8 )
+# loceee's fork of cocoaDialog renders this moot.
+#case $osxversion in	
+#	10.5 | 10.6 | 10.7 | 10.8 )
 		displayatlogout=true
-	;;
-	*)
-		displayatlogout=false
-	;;
-esac
+#	;;
+#	*)
+#		displayatlogout=false
+#	;;
+#esac
 
 
 # create the data folder if it doesn't exist
@@ -1368,20 +1369,6 @@ checkAndReadProvisionInfo()
 	fi
 }
 
-choicePrompt()
-{
-	promptdata=$(osascript << EOF
-	tell app "System Events" to activate
-	set choicelist to every paragraph of (do shell script ("cat $choicetmp"))
-	set choice to {choose from list choicelist}
-	return choice
-EOF
-	)
-	# error checking
-	echo "$(echo "$promptdata" | cut -d, -f2 | cut -d: -f2)"
-	rm "$choicetmp"
-}
-
 promptAndSetComputerName()
 {
 	# this computer must existing in the JSS... as we've been enrolled!
@@ -1391,11 +1378,12 @@ promptAndSetComputerName()
 		secho "current computername is $computername"
 		validcomputername=false
 		until $validcomputername
-		do 
-			newcomputername=$(osascript -e "display dialog \"Please confirm this Mac's computername\" default answer \"$computername\" buttons {\"Confirm and Set\"} default button 1 giving up after 600" | cut -d, -f2 | cut -d: -f2)
+		do
+			choice=$( $cdialogbin inputbox --width 430 --height 140 --title "Computer Name" --informative-text "Please confirm this Mac's computername" --text $computername --string-output --float --button1 "Confirm and Set" )
+			newcomputername=$( echo $choice | awk '{ print $4 }' )
 			if [ "$newcomputername" == "" ]
 			then
-				osascript -e "display dialog \"The computername can not be blank\" buttons {\"Oops\"} default button 1 giving up after 120"
+				$cdialogbin msgbox --width 400 --height 140 --title "Alert" --informative-text "The computer name cannot be blank" --icon hazard --float --timeout 90 --button1 "Oops"
 				continue
 			else
 				# lookup jss to ensure computername isn't in use
@@ -1406,7 +1394,7 @@ promptAndSetComputerName()
 					validcomputername=true
 				else
 					# another computer with this name exists in the JSS
-					osascript -e "display dialog \"A Mac named $newcomputername already exists in the JSS.\" buttons {\"Oops\"} default button 1 giving up after 120"
+					$cdialogbin msgbox --width 400 --height 140 --title "Alert" --informative-text "A Mac named $newcomputername already exists in the JSS." --icon hazard --float --timeout 90 --button1 "Oops"
 				fi
 			fi
 		done
@@ -1430,19 +1418,17 @@ promptProvisionInfo()
 	then
 		secho "prompting user to change provision info..."
 		provisiondetails=$(cat "$pdprovisiontmp")
-		changeprovisioninfoprompt=$(osascript -e "display dialog \"This Mac has the following provisioning information:
+		changeprovisioninfoprompt=$( $cdialogbin textbox --title "Mac Provisioning Information" --informative-text "This Mac has the following provisioning information:" --text $provisiondetails --string-output --float --timeout 600 --button2 "Change" --button1 "Continue" )
 
-$provisiondetails
-
-Would you like to change?\"  buttons {\"Change...\",\"Continue Deployment\"} default button 2 giving up after 600" | cut -d, -f1 | cut -d: -f2)
-		if [ "$changeprovisioninfoprompt" == "Continue Deployment" ]
+		if [ "$changeprovisioninfoprompt" == "Continue" ]
 		then
 			deployready=true
 			return 0
 		fi
 	else
 		secho "provisioning information incomplete..."
-		skipprompt=$(osascript -e "display dialog \"This Mac has incomplete provisioning information\"  buttons {\"Set Provisioning Info...\",\"Skip\"} default button 2 giving up after 9999" | cut -d, -f1 | cut -d: -f2)
+		skipprompt=$( $cdialogbin msgbox --width 400 --height 140 --title "Alert" --informative-text "This Mac has incomplete provisioning information" --string-output --icon hazard --float --timeout 90 --button2 "Set Info" --button1 "Skip" )
+		
 		if [ "$skipprompt" == "Skip" ]
 		then
 			deployready=true
@@ -1451,38 +1437,81 @@ Would you like to change?\"  buttons {\"Change...\",\"Continue Deployment\"} def
 	fi
 
 	if $pdusebuildea
-	then	
-		#read patchoobuilds
-		patchoobuildchoicearray=($(curl $curlopts -H "Accept: application/xml" -s -u "$apiuser:$apipass" "${jssurl}JSSResource/computerextensionattributes/name/$(echo "$pdbuildea" | sed -e 's/ /\+/g')" | xpath //computer_extension_attribute/*/popup_choices/* 2> /dev/null | sed -e 's/<choice>//g' | sed -e $'s/<\/choice>/\\\n/g'))
+	then
+		#read patchoobuilds	
+		patchoobuildchoicearray=$(curl $curlopts -H "Accept: application/xml" -s -u ${apiuser}:${apipw} --request GET ${jssadr}/JSSResource/computerextensionattributes/name/$(echo "$pdbuildea" | sed -e 's/ /\+/g')" | xpath //computer_extension_attribute/*/popup_choices/* 2> /dev/null | sed -e 's/<name>//g' | sed -e $'s/<\/name>/\\\n/g' | tr '\n' ',')
+		patchoobuildchoicearray=$( echo $patchoobuildchoicearray | sed 's/..$//' )
+
+		OIFS=$IFS
+		IFS=$','
+
 		# error checking
 		for line in "${patchoobuildchoicearray[@]}"
 		do
-		    echo "$line" >> "$choicetmp"
+			echo "$line" >> "$choicetmp"
 		done
-		patchoobuildvalue="$(choicePrompt)"
+		
+		# pop up choices dialog box. strip button report as we only want the department name.
+		patchoobuildvalue=$( $cdialogbin dropdown --width 500 --height 140 --title "EA" --text "Please Choose:" --items $(cat $choicetmp) --string-output --float --button1 "Ok" )
+		patchoobuildvalue=$( echo $deptvalue | sed -n 2p )
+
+		IFS=$OIFS
+		
+		# error checking
+		echo "$(echo "$promptdata" | cut -d, -f2 | cut -d: -f2)"
+		rm "$choicetmp"
 	fi
 
 	if $pdusedepts
-	then	
-		#read dept choices
-		deptchoicearray=($(curl $curlopts -H "Accept: application/xml" -s -u "$apiuser:$apipass" "${jssurl}JSSResource/departments" | xpath //departments/department/name 2> /dev/null | sed -e 's/<name>//g' | sed -e $'s/<\/name>/\\\n/g'))
+	then
+		#read dept choices	
+		deptchoicearray=$(curl $curlopts -H "Accept: application/xml" -s -u ${apiuser}:${apipw} --request GET ${jssadr}/JSSResource/departments | xpath //departments/department/name 2> /dev/null | sed -e 's/<name>//g' | sed -e $'s/<\/name>/\\\n/g' | tr '\n' ',')
+		deptchoicearray=$( echo $deptchoicearray | sed 's/..$//' )
+
+		OIFS=$IFS
+		IFS=$','
+
 		# error checking
 		for line in "${deptchoicearray[@]}"
 		do
-		    echo "$line" >> "$choicetmp"
+			echo "$line" >> "$choicetmp"
 		done
-		deptvalue="$(choicePrompt)"
+		
+		# pop up choices dialog box. strip button report as we only want the department name.
+		deptvalue=$( $cdialogbin dropdown --width 500 --height 140 --title "Department" --text "Please Choose:" --items $(cat $choicetmp) --string-output --float --button1 "Ok" )
+		deptvalue=$( echo $deptvalue | sed -n 2p )
+
+		IFS=$OIFS
+		
+		# error checking
+		echo "$(echo "$promptdata" | cut -d, -f2 | cut -d: -f2)"
+		rm "$choicetmp"
 	fi
 
 	if $pdusebuildings
 	then
-		#read building choices
-		buildingchoicearray=($(curl $curlopts -H "Accept: application/xml"  -s -u "$apiuser:$apipass" "${jssurl}JSSResource/buildings" | xpath //buildings/building/name 2> /dev/null | sed -e 's/<name>//g' | sed -e $'s/<\/name>/\\\n/g'))
+		#read building choices	
+		buildingchoicearray=$(curl $curlopts -H "Accept: application/xml" -s -u ${apiuser}:${apipw} --request GET ${jssadr}/JSSResource/buildings | xpath //buildings/building/name 2> /dev/null | sed -e 's/<name>//g' | sed -e $'s/<\/name>/\\\n/g' | tr '\n' ',')
+		buildingchoicearray=$( echo $buildingchoicearray | sed 's/..$//' )
+
+		OIFS=$IFS
+		IFS=$','
+
+		# error checking
 		for line in "${buildingchoicearray[@]}"
 		do
-		    echo "$line" >> "$choicetmp"
+			echo "$line" >> "$choicetmp"
 		done
-		buildingvalue="$(choicePrompt)"
+		
+		# pop up choices dialog box. strip button report as we only want the building name.
+		buildingvalue=$( $cdialogbin dropdown --width 500 --height 140 --title "Building" --text "Please Choose:" --items $(cat $choicetmp) --string-output --float --button1 "Ok" )
+		buildingvalue=$( echo $deptvalue | sed -n 2p )
+
+		IFS=$OIFS
+		
+		# error checking
+		echo "$(echo "$promptdata" | cut -d, -f2 | cut -d: -f2)"
+		rm "$choicetmp"
 	fi
 
 	# write out xml for put to api
@@ -1517,13 +1546,15 @@ Would you like to change?\"  buttons {\"Change...\",\"Continue Deployment\"} def
 	do
 		if [ "$pdapiadminname" == "" ]
 		then
-			tmpapiadminuser=$(osascript -e "display dialog \"Please enter your JSS admin username:\" default answer \"\" buttons {\"OK\"} default button 1 giving up after 9999" | cut -d, -f2 | cut -d: -f2)
+			entry=$( $cdialogbin inputbox --width 430 --height 140 --title "Username" --informative-text "Please enter your username:" --text $hardcode --string-output --float --button1 "Ok" )
+			tmpapiadminuser=$( echo $entry | awk '{ print $2 }' )
 		else
 			tmpapiadminuser="$pdapiadminname"
 		fi		
 		if [ "$pdapiadminpass" == "" ]
-		then	
-			tmpapiadminpass=$(osascript -e "display dialog \"Please enter your JSS admin password:\" default answer \"\" buttons {\"OK\"} default button 1 giving up after 9999 with hidden answer"| cut -d, -f2 | cut -d: -f2)
+		then
+			entry=$( $cdialogbin inputbox --width 430 --height 140 --title "Password" --informative-text "Please enter your password:" --text $hardcode --string-output --float --button1 "Ok" )
+			tmpapiadminpass=$( echo $entry | awk '{ print $2 }' )	
 		else
 			tmpapiadminpass="$pdapiadminpass"
 		fi
@@ -1551,8 +1582,9 @@ Would you like to change?\"  buttons {\"Change...\",\"Continue Deployment\"} def
 
 		if $retryauth
 		then
-			tryagain=$(osascript -e "display dialog \"The admin username or password was incorrect\"  buttons {\"Skip set provisioning info\",\"Try Again\"} default button 2 giving up after 9999" | cut -d, -f1 | cut -d: -f2)
-			[ "$tryagain" == "Try Again" ] && continue # loop again
+			entry=$( $cdialogbin msgbox --width 400 --height 140 --title "Alert" --informative-text "The admin username or password was incorrect" --string-output --icon hazard --float --timeout 90 --button1 "Ok" --button2 "Skip" )
+			tryagain=$( echo $entry | awk '{ print $2 }' )
+			[ "$tryagain" == "Ok" ] && continue # loop again
 		fi
 		# if we are here, all good to go
 		deployready=true
@@ -1567,13 +1599,7 @@ deploySetup()
 	touch "$pddeployreceipt"
 	deployready=false
 
-	if [ "$(checkConsoleStatus)" != "userloggedin" ] # if we don't have a logged in user, we are probably running post casper imaging or quickadd is pushed, so it's unpossible to prompt for info... skip..
-	then
-		secho "no user console session, we can't prompt for provisioning info"
-		deployready=true
-	fi
-
-	osascript -e "display dialog \"$msgpatchoodeploywelcome\"  buttons {\"...\"} default button 1 giving up after 5"
+	$cdialogbin msgbox --width 400 --height 140 --title "Deployment" --informative-text "$msgpatchoodeploywelcome" --string-output --float --timeout 5 --button1 "Ok"
 
 	until $deployready
 	do
@@ -1593,7 +1619,7 @@ deploySetup()
 	
 	if [ "$(checkConsoleStatus)" == "userloggedin" ] # if a user is logged in, prompt and restart... otherwise we'll sort that via a launchd or other method
 	then
-		osascript -e "display dialog \"Ready to provison. This Mac will restart in 2 minutes\"  buttons {\"Restart Now\"} default button 1 giving up after 120"
+		$cdialogbin msgbox --width 400 --height 140 --title "Provisioning" --informative-text "Ready to provison. This Mac will restart in 2 minutes" --string-output --float --timeout 120 --button1 "Restart"
 		#logoutUser
 		#sleep 10 # not pretty
 		reboot &


### PR DESCRIPTION
This provides support for loceee's variant of cocoaDialog which can run over the OS X loginwindow. FauxLogout functionality has not been removed but all the applescript has been replaced with equivalent cocoaDialog code and "should be" functionally equivalent.

WARNING: I do NOT have a JSS and thus this fork is HIGHLY UNTESTED and it probably riddled full of bugs. This is also highly reliant on a compatible cocoaDialog having been installed on the OS prior to any bootstrapping so include as part of your Casper Imaging workflows.